### PR TITLE
Make wavinfo work with filehandles.

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -1,0 +1,4 @@
+
+__version__ = '1.6.3'
+__author__ = 'Jamie Hardt <jamiehardt@gmail.com>'
+__license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='wavinfo',
           "Programming Language :: Python :: 3.9",
           "Programming Language :: Python :: 3.10"],
       keywords='waveform metadata audio ebu smpte avi library film tv editing editorial',
-      install_requires=['lxml', 'ear'],
+      install_requires=['lxml', 'wheel', 'ear'],
       entry_points={
           'console_scripts': [
               'wavinfo = wavinfo.__main__:main'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-from wavinfo import __author__, __license__, __version__
+from metadata import __author__, __license__, __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='wavinfo',
           "Programming Language :: Python :: 3.9",
           "Programming Language :: Python :: 3.10"],
       keywords='waveform metadata audio ebu smpte avi library film tv editing editorial',
-      install_requires=['lxml', 'wheel', 'ear'],
+      install_requires=['lxml', 'ear'],
       entry_points={
           'console_scripts': [
               'wavinfo = wavinfo.__main__:main'

--- a/tests/test_wave_parsing.py
+++ b/tests/test_wave_parsing.py
@@ -12,7 +12,7 @@ class TestWaveInfo(TestCase):
     def test_sanity(self):
         for wav_file in all_files():
             info = wavinfo.WavInfoReader(wav_file)
-            self.assertEqual(info.__repr__(), 'WavInfoReader(%s, %s, %s)'.format(wav_file, 'latin_1', 'ascii'))
+            self.assertEqual(info.__repr__(), 'WavInfoReader({}, latin_1, ascii)'.format(os.path.abspath(wav_file)))
             self.assertIsNotNone(info)
 
     def test_fmt_against_ffprobe(self):

--- a/wavinfo/__init__.py
+++ b/wavinfo/__init__.py
@@ -7,6 +7,3 @@ Go to the documentation for wavinfo.WavInfoReader for more information.
 from .wave_reader import WavInfoReader
 from .riff_parser import WavInfoEOFError
 
-__version__ = '1.6.3'
-__author__ = 'Jamie Hardt <jamiehardt@gmail.com>'
-__license__ = "MIT"


### PR DESCRIPTION
Make it possible to pass file handles or in memory wav data to wavinfo. Some of the fields for the __repr__ where not available for files. For these the url member is set to "about:blank", and the self.path to the representation of the incoming object. The formating in __repr__ turned out to be broken, with fixing that we also had to fix the test on __repr__.