### PR TITLE
Breaking interface changes in `WavInfoReader`

### DIFF
--- a/wavinfo/__main__.py
+++ b/wavinfo/__main__.py
@@ -34,7 +34,7 @@ def main():
     (options, args) = parser.parse_args(sys.argv)
     for arg in args[1:]:
         try:
-            this_file = WavInfoReader(path=arg)
+            this_file = WavInfoReader(f=arg)
             if options.adm:
                 if this_file.adm:
                     sys.stdout.write(this_file.adm.xml_str())

--- a/wavinfo/wave_reader.py
+++ b/wavinfo/wave_reader.py
@@ -29,7 +29,7 @@ class WavInfoReader:
     Parse a WAV audio file for metadata.
     """
 
-    def __init__(self, path, info_encoding='latin_1', bext_encoding='ascii'):
+    def __init__(self, f, info_encoding='latin_1', bext_encoding='ascii'):
         """
         Create a new reader object.
 
@@ -74,20 +74,20 @@ class WavInfoReader:
         #: RIFF cues markers, labels, and notes.
         self.cues :Optional[WavCuesReader] = None
 
-        if hasattr(path, 'read'):
-            self.get_wav_info(path)
+        if hasattr(f, 'read'):
+            self.get_wav_info(f)
             self.url = 'about:blank'
-            self.path = repr(path)
+            self.path = repr(f)
             
         else:
-            absolute_path = os.path.abspath(path)
+            absolute_path = os.path.abspath(f)
 
             #: `file://` url for the file.
             self.url: str = pathlib.Path(absolute_path).as_uri()
 
             self.path = absolute_path
         
-            with open(path, 'rb') as f:
+            with open(f, 'rb') as f:
                 self.get_wav_info(f)
             
     def get_wav_info(self, wavfile):


### PR DESCRIPTION
It makes more sense this way but it breaks everything prior to this version. The `path` variable in the `WavInfoReader` initializer is renamed `f`, conveying the idea that it does not have to be a path but can be an `f`, a file path or a stream. 